### PR TITLE
fix(language): Comments should be # and fix warnings

### DIFF
--- a/settings/language-simc.cson
+++ b/settings/language-simc.cson
@@ -1,0 +1,3 @@
+'.source.simc':
+  'editor':
+    'commentStart': '# '

--- a/styles/language-simc.less
+++ b/styles/language-simc.less
@@ -1,17 +1,12 @@
 @import 'ui-variables';
 
-atom-text-editor::shadow {
-  .source.simc {
-    .keyword {
-      &.control {
-        &.type {
-          color: lime;
-        }
-
-        &.actor {
-          color: orangered;
-        }
-      }
+atom-text-editor.editor {
+  .syntax--source.simc {
+    .syntax--keyword.syntax--control.syntax--type {
+      color: lime;
+    }
+    .syntax--keyword.syntax--control.actor {
+      color: orangered;
     }
   }
 }


### PR DESCRIPTION
This fixes both https://github.com/cgdangelo/language-simc/issues/2 and https://github.com/cgdangelo/language-simc/issues/1